### PR TITLE
feat(rules): unnecessary use of get

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,18 +11,20 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@typescript-eslint/parser": "^7.16.0",
-        "@typescript-eslint/utils": "^7.16.0"
+        "@typescript-eslint/utils": "^7.16.0",
+        "lodash.topath": "^4.5.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.6.0",
         "@types/jest": "^29.5.12",
+        "@types/lodash.topath": "^4.5.9",
         "@typescript-eslint/rule-tester": "^7.16.0",
         "@typescript-eslint/type-utils": "^7.16.0",
         "eslint": "^9.6.0",
         "globals": "^15.8.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.2",
-        "typescript": "^5.5.3",
+        "typescript": "^5.5.4",
         "typescript-eslint": "^7.16.0"
       },
       "peerDependencies": {
@@ -1298,6 +1300,21 @@
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
+      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.topath": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.topath/-/lodash.topath-4.5.9.tgz",
+      "integrity": "sha512-k51ecLw7Pu7GnE120R89XNpD0KyBt8gfgHjO03RvkBbmlC0S5tuuj8F8NYfU6E1xBi+/1AJIrLcsmzbeborBmQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
       }
     },
     "node_modules/@types/node": {
@@ -3628,6 +3645,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
+    "node_modules/lodash.topath": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
+      "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg=="
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4527,9 +4549,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -33,17 +33,19 @@
   "devDependencies": {
     "@eslint/js": "^9.6.0",
     "@types/jest": "^29.5.12",
+    "@types/lodash.topath": "^4.5.9",
     "@typescript-eslint/rule-tester": "^7.16.0",
     "@typescript-eslint/type-utils": "^7.16.0",
     "eslint": "^9.6.0",
     "globals": "^15.8.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.2",
-    "typescript": "^5.5.3",
+    "typescript": "^5.5.4",
     "typescript-eslint": "^7.16.0"
   },
   "dependencies": {
     "@typescript-eslint/parser": "^7.16.0",
-    "@typescript-eslint/utils": "^7.16.0"
+    "@typescript-eslint/utils": "^7.16.0",
+    "lodash.topath": "^4.5.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { rule as unnecessaryMapping } from "./rules/unnecessary-mapping-function";
+import { rule as unnecessaryGet } from "./rules/unnecessary-use-of-get";
 
 const plugin = {
   meta: {
@@ -6,6 +7,7 @@ const plugin = {
   },
   rules: {
     'unnecessary-mapping-function': unnecessaryMapping,
+    'unnecessary-use-of-get': unnecessaryGet,
   },
 };
 

--- a/src/lib/type-guards.ts
+++ b/src/lib/type-guards.ts
@@ -1,0 +1,19 @@
+import { AST_NODE_TYPES, ASTUtils, TSESTree } from "@typescript-eslint/utils";
+
+export type Expression = TSESTree.Expression;
+export type Identifier = TSESTree.Identifier;
+export type MemberExpression = TSESTree.MemberExpression;
+export type CallExpression = TSESTree.CallExpression;
+export type FunctionExpression = TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression;
+export type Literal = TSESTree.Literal;
+
+export const isMemberExpression = ASTUtils.isNodeOfType(AST_NODE_TYPES.MemberExpression);
+
+export const isSpreadElement = ASTUtils.isNodeOfType(AST_NODE_TYPES.SpreadElement);
+
+export const isLiteral = ASTUtils.isNodeOfType(AST_NODE_TYPES.Literal);
+
+export const isValidCallee = (callee: Expression): callee is Identifier | MemberExpression => {
+  return ASTUtils.isIdentifier(callee) || isMemberExpression(callee);
+}
+

--- a/src/rules/unnecessary-mapping-function.ts
+++ b/src/rules/unnecessary-mapping-function.ts
@@ -1,21 +1,10 @@
-import { AST_NODE_TYPES, ASTUtils, TSESTree } from "@typescript-eslint/utils";
+import { ASTUtils } from "@typescript-eslint/utils";
 import { ReferenceTracker } from "@typescript-eslint/utils/ast-utils";
 import { createRule } from ".";
 import { RuleContext } from "@typescript-eslint/utils/ts-eslint";
-
-type Expression = TSESTree.Expression;
-type Identifier = TSESTree.Identifier;
-type MemberExpression = TSESTree.MemberExpression;
-type CallExpression = TSESTree.CallExpression;
-type FunctionExpression = TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression;
+import { CallExpression, FunctionExpression, Identifier, isValidCallee, MemberExpression } from "../lib/type-guards";
 
 type Context = RuleContext<"avoidMapping", []>;
-
-const isMemberExpression = ASTUtils.isNodeOfType(AST_NODE_TYPES.MemberExpression);
-
-const isValidCallee = (callee: Expression): callee is Identifier | MemberExpression => {
-  return ASTUtils.isIdentifier(callee) || isMemberExpression(callee);
-}
 
 const applyRuleForNamedExports = ({
   callee: { name },

--- a/src/rules/unnecessary-use-of-get.ts
+++ b/src/rules/unnecessary-use-of-get.ts
@@ -1,0 +1,159 @@
+import ts from "typescript";
+import { ASTUtils, TSESTree } from "@typescript-eslint/utils";
+import { createRule } from ".";
+import { CallExpression, Identifier, isLiteral, isValidCallee, MemberExpression } from "../lib/type-guards";
+import { isIdentifier } from "@typescript-eslint/utils/ast-utils";
+import { Scope } from "@typescript-eslint/scope-manager";
+
+import toPath from "lodash.topath";
+import { RuleContext } from "@typescript-eslint/utils/ts-eslint";
+
+type CallExpressionArgument = TSESTree.CallExpressionArgument;
+
+type Context = RuleContext<"avoidGet", []>;
+
+const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+
+const evaluateArgument = (argument: CallExpressionArgument, scope?: Scope): unknown | undefined => {
+  if (isLiteral(argument)) {
+    return argument.value;
+  }
+
+  if (ASTUtils.isIdentifier(argument)) {
+    const staticValue = ASTUtils.getStaticValue(argument, scope);
+
+    if (staticValue === null) {
+      return undefined;
+    }
+
+    return staticValue.value;
+  }
+
+  return undefined;
+}
+
+const getCalleeName = (callee: Identifier | MemberExpression): string | undefined => {
+  if (ASTUtils.isIdentifier(callee)) {
+    return callee.name;
+  }
+
+  if (ASTUtils.isIdentifier(callee.property)) {
+    return callee.property.name;
+  }
+
+  return undefined;
+}
+
+const questionDotToken = ts.factory.createToken(ts.SyntaxKind.QuestionDotToken);
+
+const buildAccessExpression = (
+  objectArgument: Identifier,
+  path: string[],
+  shouldCoalesce: boolean
+): ts.Expression => {
+  const objectTsExpression = ts.factory.createIdentifier(objectArgument.name);
+
+  return path.reduce<ts.Expression>((expression, pathEntry, pathIndex) => {
+    const accessToken = pathIndex !== path.length - 1 && shouldCoalesce ? questionDotToken : undefined;
+
+    if (Number.isNaN(Number(pathEntry))) {
+      return ts.factory.createPropertyAccessChain(
+        expression,
+        accessToken,
+        ts.factory.createIdentifier(pathEntry),
+      )
+    }
+
+    return ts.factory.createElementAccessChain(
+      expression,
+      accessToken,
+      ts.factory.createNumericLiteral(pathEntry),
+    );
+  }, objectTsExpression);
+}
+
+const getThirdArgumentSource = (callExpression: CallExpression, context: Context): string | undefined => {
+  if (callExpression.arguments.length !== 3) {
+    return undefined;
+  }
+
+  return context.sourceCode.getText(callExpression.arguments[2])
+}
+
+export const rule = createRule({
+  name: "unnecessary-use-of-get",
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow unnecessary use of get() over accessors',
+      recommended: 'recommended',
+    },
+    schema: [],
+    messages: {
+      avoidGet: "Avoid using lodash get when null coalescing exists"
+    },
+    hasSuggestions: true,
+    fixable: "code",
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.arguments.length < 2 || node.arguments.length > 3) {
+          return;
+        }
+
+        const [objectArgument, pathArgument] = node.arguments;
+
+        if (!isValidCallee(node.callee)) {
+          return;
+        }
+
+        if (!isIdentifier(objectArgument)) {
+          return;
+        }
+
+        const calleeName = getCalleeName(node.callee);
+
+        if (calleeName !== "get") {
+          return;
+        }
+
+        const scope = context.sourceCode.getScope(context.sourceCode.ast);
+        const pathValue = evaluateArgument(pathArgument, scope);
+
+        if (typeof pathValue !== "string") {
+          return;
+        }
+
+        const path = toPath(pathValue);
+
+        const defaultValueSource = getThirdArgumentSource(node, context);
+        const shouldCoalesce = defaultValueSource !== undefined;
+
+        const replacementAccessExpression = buildAccessExpression(
+          objectArgument, path, shouldCoalesce
+        );
+
+        const replacementAccessExpressionText = printer.printNode(
+          ts.EmitHint.Unspecified,
+          replacementAccessExpression,
+          ts.createSourceFile(context.filename, context.sourceCode.text, ts.ScriptTarget.Latest, true),
+        )
+
+        context.report({
+          node,
+          messageId: "avoidGet",
+          fix(fixer) {
+            if (shouldCoalesce) {
+              return fixer.replaceText(node, `${replacementAccessExpressionText} ?? ${defaultValueSource}`);
+            }
+
+            return fixer.replaceText(node, replacementAccessExpressionText);
+          }
+        });
+      }
+    }
+  }
+})
+

--- a/tests/rules/unnecessary-use-of-get.test.ts
+++ b/tests/rules/unnecessary-use-of-get.test.ts
@@ -1,0 +1,88 @@
+import { TSESLint } from "@typescript-eslint/utils";
+import { rule } from "../../src/rules/unnecessary-use-of-get";
+
+const ruleTester = new TSESLint.RuleTester();
+
+ruleTester.run('unnecessary-use-of-get', rule, {
+  valid: [
+    {
+      code: `
+        import { get } from 'lodash';
+      `,
+    },
+    {
+      code: `
+        import _ from 'lodash';
+      `,
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        import { get } from 'lodash';
+        const appliedOffer = get(store, "offer", null);
+      `,
+      errors: [ { messageId: 'avoidGet' } ],
+      output: `
+        import { get } from 'lodash';
+        const appliedOffer = store.offer ?? null;
+      `
+    },
+    {
+      code: `
+        import { get } from 'lodash';
+        const message = get(error, "errors[0].message", error.message);
+      `,
+      errors: [ { messageId: 'avoidGet' } ],
+      output: `
+        import { get } from 'lodash';
+        const message = error?.errors?.[0].message ?? error.message;
+      `
+    },
+    {
+      code: `
+        import { get } from 'lodash';
+        const scrollTopBefore = get(document, "body.scrollTop");
+      `,
+      errors: [ { messageId: 'avoidGet' } ],
+      output: `
+        import { get } from 'lodash';
+        const scrollTopBefore = document.body.scrollTop;
+      `
+    },
+    {
+      code: `
+        import _ from 'lodash';
+        const appliedOffer = _.get(store, "offer", null);
+      `,
+      errors: [ { messageId: 'avoidGet' } ],
+      output: `
+        import _ from 'lodash';
+        const appliedOffer = store.offer ?? null;
+      `
+    },
+    {
+      code: `
+        import _ from 'lodash';
+        const message = _.get(error, "errors[0].message", error.message);
+      `,
+      errors: [ { messageId: 'avoidGet' } ],
+      output: `
+        import _ from 'lodash';
+        const message = error?.errors?.[0].message ?? error.message;
+      `
+    },
+    {
+      code: `
+        import _ from 'lodash';
+        const scrollTopBefore = _.get(document, "body.scrollTop");
+      `,
+      errors: [ { messageId: 'avoidGet' } ],
+      output: `
+        import _ from 'lodash';
+        const scrollTopBefore = document.body.scrollTop;
+      `
+    },
+  ]
+})
+


### PR DESCRIPTION
adds in a rule for checking `get()` and converting it into a reasonable property access chain

current issues:
- does not care about imports at all, so anything that looks like a `get()` will trip the rule